### PR TITLE
fix: collect pod logs after helm test (FB-1643)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # firebolt-instance-helm
 
-Helm chart for running a Firebolt instance on Kubernetes: Envoy gateway, Metadata Service, PostgreSQL, and one or more Firebolt query engine StatefulSets.
+Helm chart for running a Firebolt instance on Kubernetes: Gateway (Envoy), Metadata Service, PostgreSQL and one or more Firebolt Engines.
 
 The chart is published as `firebolt-instance` to `oci://ghcr.io/firebolt-db/helm-charts` on every change to `helm/` merged to `main`.
 
@@ -9,7 +9,7 @@ For more detailed information checkout our [official documentation](https://docs
 
 ## Scope
 
-The chart deploys a complete Firebolt instance — gateway, metadata, PostgreSQL, engines — into any Kubernetes cluster. For day-2 operational capabilities (zero-downtime engine rollouts, autoscaling, drift correction, reusable per-engine templates), use the [Firebolt Kubernetes Operator](docs/operator-upgrade-path.mdx). See [`docs/`](docs/) for usage patterns.
+The chart deploys a complete Firebolt Instance consistingo of a Gateway (Envoy), Metadata Service, PostgreSQL and Firebolt Engines into any Kubernetes cluster. For day-2 operational capabilities (zero-downtime engine rollouts, autoscaling, drift correction, reusable per-engine templates), take a look at the [Firebolt Kubernetes Operator](https://github.com/firebolt-db/firebolt-kubernetes-operator).
 
 ## Architecture
 

--- a/helm/AGENTS.md
+++ b/helm/AGENTS.md
@@ -70,10 +70,12 @@ The Helm chart itself, packaged and published as `firebolt-instance` to `oci://g
 ## Adding a new helm test
 
 1. Create `templates/tests/test-<name>.yaml` as a `Pod` with `metadata.annotations."helm.sh/hook": test`.
-2. Use `fbinstance.testShellHelpers` for the `log` / `pass` / `fail` shell helpers.
-3. Use `fbinstance.fullname` and `fbinstance.selectorLabels` for any name or selector.
-4. Verify with `make test` (which passes `--logs`, so any failure surfaces directly).
+2. Set `metadata.annotations."helm.sh/hook-delete-policy": before-hook-creation` (and only that — see "Known issues" below for why `hook-succeeded` is forbidden on test pods).
+3. Use `fbinstance.testShellHelpers` for the `log` / `pass` / `fail` shell helpers.
+4. Use `fbinstance.fullname` and `fbinstance.selectorLabels` for any name or selector.
+5. Verify with `make test` (which passes `--logs`, so any failure surfaces directly).
 
 ## Known issues
 
 - Symptom: engine pods can fail during startup if the chart moves `--data-dir` or the `data` volume away from `/firebolt-core/volume`. Cause: the engine treats `/firebolt-core/volume` as its writable runtime data directory. Resolution: keep the `data` mount, `--data-dir`, `config.yaml`, `auth.json`, and memlock PID files under `/firebolt-core/volume`.
+- Symptom: `make test` (i.e. `helm test --logs`) prints `Phase: Succeeded` for every suite and then exits 1 with `unable to get pod logs ... pods "<release>-test-<name>" not found`. Cause: a `helm.sh/hook-delete-policy` of `before-hook-creation,hook-succeeded` on the test pod tells helm to delete the pod the moment the hook succeeds, so by the time `helm test --logs` iterates the pods to fetch their logs they are already gone (helm/helm#8949). Resolution: test pods MUST set `helm.sh/hook-delete-policy: before-hook-creation` only — never include `hook-succeeded`. Stale pods are still cleaned up on the next `helm test` run by `before-hook-creation`, and `make test-cleanup` deletes them on demand.

--- a/helm/templates/tests/test-auth-configmap.yaml
+++ b/helm/templates/tests/test-auth-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: test
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   restartPolicy: Never
   volumes:

--- a/helm/templates/tests/test-engine-configmaps.yaml
+++ b/helm/templates/tests/test-engine-configmaps.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: test
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   restartPolicy: Never
   volumes:

--- a/helm/templates/tests/test-engine-dns.yaml
+++ b/helm/templates/tests/test-engine-dns.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: test
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   restartPolicy: Never
   containers:

--- a/helm/templates/tests/test-engine-pods-reachable.yaml
+++ b/helm/templates/tests/test-engine-pods-reachable.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: test
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   restartPolicy: Never
   containers:

--- a/helm/templates/tests/test-engine-ready.yaml
+++ b/helm/templates/tests/test-engine-ready.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "fbinstance.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: test
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   restartPolicy: Never
   containers:

--- a/helm/templates/tests/test-gateway-ready.yaml
+++ b/helm/templates/tests/test-gateway-ready.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: test
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   restartPolicy: Never
   containers:

--- a/helm/templates/tests/test-metadata-service.yaml
+++ b/helm/templates/tests/test-metadata-service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: test
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   restartPolicy: Never
   containers:

--- a/helm/templates/tests/test-namespace-dns.yaml
+++ b/helm/templates/tests/test-namespace-dns.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: test
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   restartPolicy: Never
   containers:

--- a/helm/templates/tests/test-postgres.yaml
+++ b/helm/templates/tests/test-postgres.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: test
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   restartPolicy: Never
   containers:

--- a/helm/templates/tests/test-smoke.yaml
+++ b/helm/templates/tests/test-smoke.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "fbinstance.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: test
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   restartPolicy: Never
   containers:

--- a/helm/templates/tests/test-sql-query.yaml
+++ b/helm/templates/tests/test-sql-query.yaml
@@ -11,7 +11,7 @@ metadata:
     firebolt/engine: {{ $engine.name }}
   annotations:
     helm.sh/hook: test
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   restartPolicy: Never
   containers:


### PR DESCRIPTION
**Background**

FB-1643: collect pod logs after helm test

**Summary**
helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded deletes test pods the moment they succeed, so `helm test --logs` races and exits 1 with "pods not found" even when every suite passed (helm/helm#8949). Drop hook-succeeded from every test under helm/templates/tests/; pods are still cleaned up on the next test run by before-hook creation, and `make test-cleanup` remains for explicit cleanup.

**Test Plan**
make test