### PR TITLE
chore(deps): bump packdb appVersion to release-5.0.1-0.20260709071413.53735f172429

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -30,7 +30,16 @@ jobs:
     permissions:
       contents: read
     outputs:
-      docs_only: ${{ steps.detect.outputs.docs_only }}
+      # helm-test is a required check, so the job must always run and report a
+      # conclusion — a job-level `if` would leave branch protection waiting on
+      # a check that never reports. The skip decision is exported here instead,
+      # and every step in helm-test no-ops on it, so the check completes green
+      # without the 45-minute kind run. Skipped cases:
+      #   - docs-only PRs (nothing the e2e suite covers changed);
+      #   - release-please's release PRs: they only bump Chart.yaml `version` +
+      #     CHANGELOG.md over templates that already passed e2e on the feature
+      #     PR, and a flake would needlessly block the release.
+      skip: ${{ steps.detect.outputs.docs_only == 'true' || startsWith(github.head_ref, 'release-please') }}
     steps:
       - name: Determine whether the PR changed only docs
         id: detect
@@ -60,11 +69,10 @@ jobs:
   helm-test:
     name: helm-test (k8s ${{ matrix.k8s-version }})
     needs: detect
-    # Skip release-please's release PRs: they only bump Chart.yaml `version` +
-    # CHANGELOG.md over templates that already passed e2e on the feature PR, so
-    # re-running the 45-minute kind suite adds no coverage and a flake there
-    # would needlessly block the release.
-    if: needs.detect.outputs.docs_only != 'true' && !startsWith(github.head_ref, 'release-please')
+    # No job-level `if`: this is a required check, so it must always report.
+    # When `needs.detect.outputs.skip` is true every step below no-ops and the
+    # job succeeds immediately (see the `skip` output in `detect` for when and
+    # why).
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -81,7 +89,14 @@ jobs:
           - k8s-version: "1.35"
             node-image: "kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f"
     steps:
+      - name: Explain the no-op
+        if: needs.detect.outputs.skip == 'true'
+        run: |
+          echo "Docs-only or release-please PR — skipping the e2e suite and" \
+            "reporting success so the required check passes."
+
       - name: Free up disk space on the runner
+        if: needs.detect.outputs.skip != 'true'
         run: |
           df -h /
           sudo rm -rf /usr/lib/jvm /usr/local/.ghcup /opt/ghc \
@@ -91,6 +106,7 @@ jobs:
           df -h /
 
       - name: Raise memlock limit for kind nodes (engine io_uring)
+        if: needs.detect.outputs.skip != 'true'
         run: |
           # The engine maps io_uring buffers and needs a high memlock limit.
           # Containers inherit it from the Docker daemon, so raise it there
@@ -112,11 +128,13 @@ jobs:
           sudo systemctl restart docker
 
       - name: Checkout code
+        if: needs.detect.outputs.skip != 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Install kind
+        if: needs.detect.outputs.skip != 'true'
         env:
           KIND_VERSION: v0.32.0
         run: |
@@ -127,6 +145,7 @@ jobs:
           kind version
 
       - name: Set up Helm
+        if: needs.detect.outputs.skip != 'true'
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           # Stay on Helm v3 (see helm-validate.yaml for the rationale).
@@ -136,20 +155,22 @@ jobs:
         # While the engine/metadata packages are private, the host's docker pull
         # in load-e2e-images.sh needs GHCR auth or it 401s. Skipped once the
         # packages are public (GHCR_PACKAGES_PUBLIC=true) — anonymous pulls work.
-        if: env.GHCR_PACKAGES_PUBLIC != 'true'
+        if: needs.detect.outputs.skip != 'true' && env.GHCR_PACKAGES_PUBLIC != 'true'
         env:
           GHCR_USER: ${{ github.actor }}
           GHCR_TOKEN: ${{ github.token }}
         run: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
 
       - name: Prepare kind cluster and load images
+        if: needs.detect.outputs.skip != 'true'
         env:
           NODE_IMAGE: ${{ matrix.node-image }}
         run: make prepare-test-e2e
 
       - name: Run quickstart end-to-end check
+        if: needs.detect.outputs.skip != 'true'
         run: make helm-test
 
       - name: Delete kind cluster
-        if: always()
+        if: always() && needs.detect.outputs.skip != 'true'
         run: make cleanup-test-e2e || true

--- a/docs/usage/image-overrides.mdx
+++ b/docs/usage/image-overrides.mdx
@@ -31,10 +31,10 @@ You can choose the smaller `release-` versions or use the `debug-` prefix which 
 ```yaml
 engineSpec:
   image:
-    tag: release-4.32.0-pre.0.20260609145613.22a1ea4abadb
+    tag: release-5.0.1-0.20260709071413.53735f172429
 metadata:
   image:
-    tag: release-4.32.0-pre.0.20260609145613.22a1ea4abadb
+    tag: release-5.0.1-0.20260709071413.53735f172429
 ```
 
 ## Lockstep

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -8,4 +8,4 @@ home: "https://github.com/firebolt-db/firebolt-instance-helm"
 sources: ["https://github.com/firebolt-db/firebolt-instance-helm"]
 version: 0.2.0
 # Bumped by upstream image-release automation.
-appVersion: "release-5.0.1-0.20260622084213.3ef06de4e9aa"
+appVersion: "release-5.0.1-0.20260709071413.53735f172429"

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # firebolt-instance
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-5.0.1-0.20260622084213.3ef06de4e9aa](https://img.shields.io/badge/AppVersion-release--5.0.1--0.20260622084213.3ef06de4e9aa-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-5.0.1-0.20260709071413.53735f172429](https://img.shields.io/badge/AppVersion-release--5.0.1--0.20260709071413.53735f172429-informational?style=flat-square)
 
 Firebolt Instance on Kubernetes — Envoy gateway, metadata, auth, and engines
 
@@ -34,6 +34,8 @@ Firebolt Instance on Kubernetes — Envoy gateway, metadata, auth, and engines
 | engineSpec.defaultStorage | object | {} | Default PVC storage spec for engines. `storageClassName` is intentionally absent — the cluster default storage class is used. Override here or per-engine to specify a class (e.g. `storageClassName: gp3`). |
 | engineSpec.defaultStorage.accessModes | list | `["ReadWriteOnce"]` | Access modes for the default PVC. |
 | engineSpec.defaultStorage.resources.requests.storage | string | `"100Gi"` | Default storage size for engine PVCs. |
+| engineSpec.extraEnv | list | [] | Extra environment variables for the engine container. Use this to inject AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (for example via `valueFrom.secretKeyRef`) for a custom S3-compatible store (`managed_table_storage: s3` + `aws.endpoint`). |
+| engineSpec.extraEnvFrom | list | [] | Extra `envFrom` sources for the engine container. Use a `secretRef` to load a Secret holding AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY for a custom S3-compatible store. |
 | engineSpec.hostPathStorageEnabled | bool | `false` | When true, uses hostPath instead of PVC for engine data. |
 | engineSpec.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | engineSpec.image.repository | string | `"ghcr.io/firebolt-db/engine"` | Container repository for the Firebolt engine image. |


### PR DESCRIPTION
## Summary

Bump `appVersion` in `helm/Chart.yaml` to `release-5.0.1-0.20260709071413.53735f172429`
— the build the engine/metadata `:latest` GHCR tags were just re-pointed to —
regenerate the `helm/README.md` badge, and refresh the image-overrides example.

> [!NOTE]
> Opened automatically by packdb's `promote-ghcr-latest` workflow (weekly
> Monday refresh or a manual promotion) right after it re-pointed the
> engine/metadata `:latest` GHCR tags at this build, so `:latest` and this
> repo's pinned tags move together. An unmerged PR is overwritten by the
> next run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine image pin and doc/README refresh; the workflow change only alters when the e2e suite runs, not chart runtime behavior.
> 
> **Overview**
> Bumps **`helm/Chart.yaml` `appVersion`** (and the **`helm/README.md`** badge) to **`release-5.0.1-0.20260709071413.53735f172429`**, aligning the chart’s default engine/metadata tags with the latest GHCR promotion. The **image-overrides** doc example uses the same tag pair.
> 
> Refactors **`.github/workflows/helm-test.yaml`** so the **`helm-test` job always runs and reports** (required check): the detect job now exports a combined **`skip`** flag for docs-only PRs and **`release-please`** branches, and each heavy step no-ops when skipped instead of skipping the whole job with a job-level `if`.
> 
> Regenerated **`helm/README.md`** values table also documents **`engineSpec.extraEnv`** and **`engineSpec.extraEnvFrom`** for custom S3 credential injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b1e74fa73634a1d0dd4858a3e0e62eecf9d54db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->