### PR TITLE
chore(deps): bump packdb appVersion to release-5.0.1-0.20260713060957.513515666721

### DIFF
--- a/docs/usage/image-overrides.mdx
+++ b/docs/usage/image-overrides.mdx
@@ -31,10 +31,10 @@ You can choose the smaller `release-` versions or use the `debug-` prefix which 
 ```yaml
 engineSpec:
   image:
-    tag: release-5.0.1-0.20260709071413.53735f172429
+    tag: release-5.0.1-0.20260713060957.513515666721
 metadata:
   image:
-    tag: release-5.0.1-0.20260709071413.53735f172429
+    tag: release-5.0.1-0.20260713060957.513515666721
 ```
 
 ## Lockstep

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -8,4 +8,4 @@ home: "https://github.com/firebolt-db/firebolt-instance-helm"
 sources: ["https://github.com/firebolt-db/firebolt-instance-helm"]
 version: 0.2.0
 # Bumped by upstream image-release automation.
-appVersion: "release-5.0.1-0.20260709071413.53735f172429"
+appVersion: "release-5.0.1-0.20260713060957.513515666721"

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # firebolt-instance
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-5.0.1-0.20260709071413.53735f172429](https://img.shields.io/badge/AppVersion-release--5.0.1--0.20260709071413.53735f172429-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-5.0.1-0.20260713060957.513515666721](https://img.shields.io/badge/AppVersion-release--5.0.1--0.20260713060957.513515666721-informational?style=flat-square)
 
 Firebolt Instance on Kubernetes — Envoy gateway, metadata, auth, and engines
 


### PR DESCRIPTION
## Summary

Bump `appVersion` in `helm/Chart.yaml` to `release-5.0.1-0.20260713060957.513515666721`
— the build the engine/metadata `:latest` GHCR tags were just re-pointed to —
regenerate the `helm/README.md` badge, and refresh the image-overrides example.

> [!NOTE]
> Opened automatically by packdb's `promote-ghcr-latest` workflow (weekly
> Monday refresh or a manual promotion) right after it re-pointed the
> engine/metadata `:latest` GHCR tags at this build, so `:latest` and this
> repo's pinned tags move together. An unmerged PR is overwritten by the
> next run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine image pin bump with no chart logic or values changes; engine and metadata tags remain in lockstep as before.
> 
> **Overview**
> Updates the chart’s pinned **engine/metadata** build from `release-5.0.1-0.20260709071413.53735f172429` to **`release-5.0.1-0.20260713060957.513515666721`** so default installs stay aligned with the GHCR `:latest` promotion.
> 
> **`helm/Chart.yaml`** `appVersion` is the only functional pin change (chart `version` remains `0.2.0`). **`helm/README.md`** AppVersion badge and **`docs/usage/image-overrides.mdx`** lockstep override example are refreshed to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 751b7b1bbdfae18ae8a8eb6f9dd6587c91d21a8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->