### PR TITLE
ci: run helm-test on engine-release image bump PRs (FB-2191)

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -36,9 +36,12 @@ jobs:
       # and every step in helm-test no-ops on it, so the check completes green
       # without the 45-minute kind run. Skipped cases:
       #   - docs-only PRs (nothing the e2e suite covers changed);
-      #   - release-please's release PRs: they only bump Chart.yaml `version` +
-      #     CHANGELOG.md over templates that already passed e2e on the feature
-      #     PR, and a flake would needlessly block the release.
+      #   - release-please's chart release PRs: they only bump Chart.yaml
+      #     `version` + CHANGELOG.md over templates that already passed e2e on
+      #     the feature PR, and a flake would needlessly block the release.
+      #   Packdb image bumps use `engine-release/bump-packdb` instead — those
+      #     PRs must run the full e2e suite (see packdb API-release-flow /
+      #     promote-ghcr-latest).
       skip: ${{ steps.detect.outputs.docs_only == 'true' || startsWith(github.head_ref, 'release-please') }}
     steps:
       - name: Determine whether the PR changed only docs
@@ -92,8 +95,8 @@ jobs:
       - name: Explain the no-op
         if: needs.detect.outputs.skip == 'true'
         run: |
-          echo "Docs-only or release-please PR — skipping the e2e suite and" \
-            "reporting success so the required check passes."
+          echo "Docs-only or release-please chart-release PR — skipping the e2e" \
+            "suite and reporting success so the required check passes."
 
       - name: Free up disk space on the runner
         if: needs.detect.outputs.skip != 'true'

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
-    if: ${{ !startsWith(github.head_ref, 'dependabot') && !startsWith(github.head_ref, 'release-please') }}
+    if: ${{ !startsWith(github.head_ref, 'dependabot') && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'engine-release') }}
     steps:
       - name: Validate PR title
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,14 +96,6 @@ You MUST keep documentation in sync with code. When making changes:
 
 A pull request that changes structure or interfaces without a documentation update is incomplete.
 
-## Document resolved issues
-
-You MUST capture non-obvious problems you solve. When you encounter and fix a quirk, footgun, surprising framework behavior, environment trap, or anything that took meaningful debugging:
-
-- Add a short entry to `## Known issues` in the most-relevant `AGENTS.md` (root for project-wide; `helm/AGENTS.md` for chart-specific).
-- State the symptom, the cause, and the resolution in two or three sentences.
-- This prevents the next agent from rediscovering the same problem.
-
 ## Proactive harness
 
 Code is not done until it is covered by tests where tests are reasonable.
@@ -134,6 +126,12 @@ Linear specifics:
 - Any new Linear issue created in connection with this repo MUST be filed under team `Firebolt` AND project `Firebolt Instance Helm Chart`. Filing it in the team without the project leaves it unscoped.
 
 ## Known issues
+
+Ongoing limitations, framework footguns, and environment traps that still affect day-to-day work and need a **workaround** until the root cause is fixed.
+
+- Do **not** add entries for bugs you fix in the current PR. The code change and PR description are the record.
+- When you add an entry, put it in the most-relevant `AGENTS.md` (root for project-wide; `helm/AGENTS.md` for chart-specific). State the symptom, cause, and workaround in two or three sentences.
+- Remove the entry when the underlying issue is fixed — do not leave solved history behind.
 
 - Symptom: GitHub Actions workflows that use `azure/setup-helm` with `version: "latest"` can start failing or changing behavior unexpectedly. Cause: the action matches upstream Helm tarball names verbatim and `latest` can silently advance across major versions, including to Helm v4. Resolution: pin an explicit Helm v3 patch in both validation and release workflows until the v4 behavioral differences have been audited and adopted intentionally.
 


### PR DESCRIPTION
## Background
FB-2191: Packdb image bump PRs were opened on `release-please/bump-packdb`, so `helm-test` skipped e2e and bad engine/appVersion combinations could merge undetected.

## Summary
- Document that `helm-test` skips only docs-only and `release-please/*` chart-release PRs; packdb bumps on `engine-release/bump-packdb` run the full quickstart suite.
- Exempt `engine-release/*` from the PR title gate.
- Remove the `Document resolved issues` section and clarify `## Known issues` is for ongoing workarounds only.

## Test plan
- [ ] CI passes on this PR.
- [ ] After packdb merges, the next `engine-release/bump-packdb` bump PR runs `helm-test` end-to-end (not the 2-second skip path).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow skip logic is unchanged; updates are comments, a PR-title gate exemption for automation branches, and agent documentation.
> 
> **Overview**
> Packdb image bump PRs are expected on **`engine-release/bump-packdb`** instead of **`release-please/*`**, so they are no longer covered by the existing `helm-test` skip for `release-please` branches and should run the full kind quickstart e2e. This change **documents** that split in `helm-test.yaml` (skip remains docs-only + `release-please` chart-release PRs) and tweaks the skip log message wording.
> 
> The **PR Title** workflow now skips conventional-commit validation for branches under **`engine-release/`**, alongside dependabot and release-please.
> 
> **`AGENTS.md`** drops the “Document resolved issues” requirement and clarifies **`## Known issues`** is only for ongoing workarounds—not bugs fixed in the same PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 067588e67fc28ac380e18ce0838500943fe88d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->