### PR TITLE
fix(scripts): align deploy.sh floci storage with engine schema (FB-2191)

### DIFF
--- a/local-floci.yaml
+++ b/local-floci.yaml
@@ -9,8 +9,7 @@
 #   make install   # or make upgrade
 #
 # Floci is zero-auth: SigV4 still required but credentials aren't validated.
-# `type: minio` in the engine config hardcodes the access/secret to
-# `firebolt/firebolt`, which floci accepts.
+# Supply any AWS creds via engineSpec.extraEnv (see docs/quickstart.mdx).
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/scripts/lib/deploy.sh
+++ b/scripts/lib/deploy.sh
@@ -217,13 +217,20 @@ deploy_and_verify() {
   my_values="$(mktemp)"
   trap 'rm -f "'"${my_values}"'"' RETURN
   cat > "${my_values}" <<EOF
+engineSpec:
+  extraEnv:
+    - name: AWS_ACCESS_KEY_ID
+      value: firebolt
+    - name: AWS_SECRET_ACCESS_KEY
+      value: firebolt
+
 customEngineConfig:
   storage:
-    type: minio
-    api_scheme: "s3://"
-    bucket_name: firebolt-managed
-    minio:
+    managed_table_storage: s3
+    managed_table_bucket_name: firebolt-managed
+    aws:
       endpoint: http://floci.${namespace}.svc.cluster.local:4566
+      path_style_addressing: true
 EOF
 
   # Helm value args: the floci storage block (always), then each caller-supplied


### PR DESCRIPTION
## Background
FB-2191: After packdb image bumps land on `engine-release/bump-packdb`, `helm-test` runs the full quickstart suite — but `scripts/lib/deploy.sh` still generated the removed `type: minio` / `api_scheme` storage keys, so the engine failed config parse and the StatefulSet never became Ready.

## Summary
- Update the floci-backed `my-values.yaml` block in `deploy_and_verify` to match `docs/quickstart.mdx` / `helm/values-dev.yaml`: `managed_table_storage: s3`, `managed_table_bucket_name`, `aws.endpoint`, `path_style_addressing`, and `engineSpec.extraEnv` AWS credentials.
- Refresh the stale comment in `local-floci.yaml`.

## Test plan
- [ ] CI `helm-test` passes on this PR (engine reaches Ready and smoke query succeeds).
- [ ] Companion PR #33 merged or this branch rebased once that lands (not strictly required for this fix to be testable on its own).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/deploy script and comment-only manifest change; no runtime auth or production storage path changes beyond fixing config parse for local floci.
> 
> **Overview**
> Fixes **helm-test / `deploy_and_verify`** so the generated floci values match the current engine storage config (same shape as `docs/quickstart.mdx` and `helm/values-dev.yaml`).
> 
> The temp `my-values.yaml` no longer emits removed keys (`type: minio`, `api_scheme`, nested `minio:`). It now sets **`managed_table_storage: s3`**, **`managed_table_bucket_name`**, **`aws.endpoint`** and **`path_style_addressing`**, and injects **`engineSpec.extraEnv`** with placeholder AWS credentials for zero-auth floci.
> 
> **`local-floci.yaml`** comment only: documents creds via `engineSpec.extraEnv` instead of implying minio-type config hardcodes them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dad24d6576974ed92719fe7891ee8ef1131c8870. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->