### PR TITLE
fix(agent): remove floci AWS env credentials (FB-2197)

### DIFF
--- a/docs-internal/local-development.md
+++ b/docs-internal/local-development.md
@@ -25,7 +25,7 @@ make test
 
 ## Why floci
 
-The metadata images shipped after 2026-05-13 refuse local-filesystem managed storage in dedicated-Pensieve mode. `values-dev.yaml` sets `customEngineConfig.storage` to `type: minio`, which hardcodes the S3 access/secret to `firebolt/firebolt` — floci (zero-auth) signs through without any env-var plumbing.
+The metadata images shipped after 2026-05-13 refuse local-filesystem managed storage in dedicated-Pensieve mode. `values-dev.yaml` points `customEngineConfig.storage` at floci (`managed_table_storage: s3` plus `aws.endpoint`) so local installs use object storage without cloud infrastructure.
 
 ## Reset floci
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -70,17 +70,10 @@ floci stores data in the pod's ephemeral filesystem and validates no credentials
 
 ## Configure the engine
 
-Create a values file that points the engine's storage at the floci endpoint. `managed_table_storage: s3` with `aws.endpoint` targets floci, and `managed_table_bucket_name` matches the bucket floci created. floci is zero-auth, so any AWS credentials work (set via `engineSpec.extraEnv`).
+Create a values file that points the engine's storage at the floci endpoint. `managed_table_storage: s3` with `aws.endpoint` targets floci, and `managed_table_bucket_name` matches the bucket floci created.
 
 ```yaml
 # my-values.yaml
-engineSpec:
-  extraEnv:
-    - name: AWS_ACCESS_KEY_ID
-      value: firebolt
-    - name: AWS_SECRET_ACCESS_KEY
-      value: firebolt
-
 customEngineConfig:
   storage:
     managed_table_storage: s3

--- a/helm/templates/tests/test-sql-query.yaml
+++ b/helm/templates/tests/test-sql-query.yaml
@@ -61,19 +61,33 @@ spec:
           [ -n "$ACCESS_TOKEN" ] \
             || fail "did not receive access_token, response: $TOKEN_RESPONSE"
           {{- end }}
-          log "SQL: SELECT 1 via gateway (engine: $ENGINE)"
-          RESPONSE=$(curl --fail --silent $CURL_INSECURE \
-            --retry 10 --retry-delay 5 --retry-connrefused \
-            --max-time 30 \
-            -X POST "$GW/" \
-            -H "X-Firebolt-Engine: $ENGINE" \
-            {{- if $.Values.auth.enabled }}
-            -H "Authorization: Bearer $ACCESS_TOKEN" \
-            {{- end }}
-            -H "Content-Type: text/plain" \
-            --data "SELECT 1")
-          echo "Response: $RESPONSE"
-          echo "$RESPONSE" | grep -q "1" || fail "unexpected response from gateway"
-          pass "SELECT 1 returned a result containing '1'"
+          sql_query() {
+            LABEL="$1"
+            QUERY="$2"
+            EXPECTED="$3"
+            log "SQL: $LABEL via gateway (engine: $ENGINE)"
+            RESPONSE=$(curl --fail --silent $CURL_INSECURE \
+              --retry 10 --retry-delay 5 --retry-connrefused \
+              --max-time 30 \
+              -X POST "$GW/" \
+              -H "X-Firebolt-Engine: $ENGINE" \
+              {{- if $.Values.auth.enabled }}
+              -H "Authorization: Bearer $ACCESS_TOKEN" \
+              {{- end }}
+              -H "Content-Type: text/plain" \
+              --data "$QUERY")
+            echo "Response: $RESPONSE"
+            echo "$RESPONSE" | grep -q "$EXPECTED" || fail "unexpected response for $LABEL"
+          }
+
+          sql_query "SELECT 1" "SELECT 1" "1"
+
+          TABLE="helm_storage_smoke_$(printf '%s' "$ENGINE" | tr -c 'A-Za-z0-9_' '_')"
+          sql_query "managed table cleanup" "DROP TABLE IF EXISTS $TABLE" "OK"
+          sql_query "managed table create" "CREATE TABLE $TABLE (id INT, name TEXT)" "OK"
+          sql_query "managed table insert" "INSERT INTO $TABLE (id, name) VALUES (1, 'floci'), (2, 'managed-storage')" "OK"
+          sql_query "managed table select" "SELECT name FROM $TABLE WHERE id = 2" "managed-storage"
+          sql_query "managed table final cleanup" "DROP TABLE IF EXISTS $TABLE" "OK"
+          pass "SELECT 1 and managed-table read/write checks passed"
 {{- end }}
 {{- end }}

--- a/helm/templates/tests/test-sql-query.yaml
+++ b/helm/templates/tests/test-sql-query.yaml
@@ -77,17 +77,18 @@ spec:
               -H "Content-Type: text/plain" \
               --data "$QUERY")
             echo "Response: $RESPONSE"
-            echo "$RESPONSE" | grep -q "$EXPECTED" || fail "unexpected response for $LABEL"
+            [ -z "$EXPECTED" ] || echo "$RESPONSE" | grep -q "$EXPECTED" \
+              || fail "unexpected response for $LABEL"
           }
 
           sql_query "SELECT 1" "SELECT 1" "1"
 
           TABLE="helm_storage_smoke_$(printf '%s' "$ENGINE" | tr -c 'A-Za-z0-9_' '_')"
-          sql_query "managed table cleanup" "DROP TABLE IF EXISTS $TABLE" "OK"
-          sql_query "managed table create" "CREATE TABLE $TABLE (id INT, name TEXT)" "OK"
-          sql_query "managed table insert" "INSERT INTO $TABLE (id, name) VALUES (1, 'floci'), (2, 'managed-storage')" "OK"
+          sql_query "managed table cleanup" "DROP TABLE IF EXISTS $TABLE" ""
+          sql_query "managed table create" "CREATE TABLE $TABLE (id INT, name TEXT)" ""
+          sql_query "managed table insert" "INSERT INTO $TABLE (id, name) VALUES (1, 'floci'), (2, 'managed-storage')" ""
           sql_query "managed table select" "SELECT name FROM $TABLE WHERE id = 2" "managed-storage"
-          sql_query "managed table final cleanup" "DROP TABLE IF EXISTS $TABLE" "OK"
+          sql_query "managed table final cleanup" "DROP TABLE IF EXISTS $TABLE" ""
           pass "SELECT 1 and managed-table read/write checks passed"
 {{- end }}
 {{- end }}

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -10,12 +10,6 @@
 engineSpec:
   image:
     tag: dev
-  # floci is zero-auth; the engine still signs S3 requests, so supply any creds.
-  extraEnv:
-    - name: AWS_ACCESS_KEY_ID
-      value: firebolt
-    - name: AWS_SECRET_ACCESS_KEY
-      value: firebolt
 
 metadata:
   image:
@@ -23,8 +17,7 @@ metadata:
 
 # Point the engine's managed storage at the local floci S3 emulator. The engine
 # refuses to start in dedicated-Pensieve mode without managed storage on object
-# storage. floci is zero-auth, so any AWS creds work (set via engineSpec.extraEnv
-# above). Apply local-floci.yaml in the same namespace before `make install`.
+# storage. Apply local-floci.yaml in the same namespace before `make install`.
 customEngineConfig:
   storage:
     managed_table_storage: s3

--- a/local-floci.yaml
+++ b/local-floci.yaml
@@ -8,8 +8,7 @@
 #   kubectl -n firebolt rollout status deployment/floci --timeout=120s
 #   make install   # or make upgrade
 #
-# Floci is zero-auth: SigV4 still required but credentials aren't validated.
-# Supply any AWS creds via engineSpec.extraEnv (see docs/quickstart.mdx).
+# Floci is zero-auth and validates no object-storage credentials.
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/scripts/lib/deploy.sh
+++ b/scripts/lib/deploy.sh
@@ -131,6 +131,23 @@ run_query() {
   return 1
 }
 
+# Exercise the managed-table path against the configured object store. SELECT 1
+# proves the gateway and query listener work; this sequence proves the engine can
+# create table metadata, write table data, and read it back using the chart's
+# customEngineConfig.storage block.
+run_managed_table_smoke() {
+  local namespace="$1"
+  local gateway="$2"
+  local engine="$3"
+  local table="helm_storage_smoke"
+
+  run_query "${namespace}" "${gateway}" "${engine}" "DROP TABLE IF EXISTS ${table}" "OK"
+  run_query "${namespace}" "${gateway}" "${engine}" "CREATE TABLE ${table} (id INT, name TEXT)" "OK"
+  run_query "${namespace}" "${gateway}" "${engine}" "INSERT INTO ${table} (id, name) VALUES (1, 'floci'), (2, 'managed-storage')" "OK"
+  run_query "${namespace}" "${gateway}" "${engine}" "SELECT name FROM ${table} WHERE id = 2" "managed-storage"
+  run_query "${namespace}" "${gateway}" "${engine}" "DROP TABLE IF EXISTS ${table}" "OK"
+}
+
 # Current pipeline phase and the failure_reason to report if this phase fails.
 # Both helm-test.sh (human output) and scripts/agent/up.sh (JSON output) walk the same
 # phases via deploy_and_verify; scripts/agent/up.sh reads these globals in its EXIT trap
@@ -287,6 +304,11 @@ EOF
   # also absorbs the engine's post-rollout warm-up before the (optional) suite.
   set_phase query query_failed
   run_query "${namespace}" "${gateway}" "${engine}"
+
+  # The local quickstart config points managed-table storage at floci. A simple
+  # table write/read catches storage config regressions that SELECT 1 cannot.
+  set_phase managed_table managed_table_failed
+  run_managed_table_smoke "${namespace}" "${gateway}" "${engine}"
 
   # --- Thorough verification (opt-in) ---------------------------------------
   # THOROUGH=true additionally runs the chart's full helm test suite

--- a/scripts/lib/deploy.sh
+++ b/scripts/lib/deploy.sh
@@ -217,13 +217,6 @@ deploy_and_verify() {
   my_values="$(mktemp)"
   trap 'rm -f "'"${my_values}"'"' RETURN
   cat > "${my_values}" <<EOF
-engineSpec:
-  extraEnv:
-    - name: AWS_ACCESS_KEY_ID
-      value: firebolt
-    - name: AWS_SECRET_ACCESS_KEY
-      value: firebolt
-
 customEngineConfig:
   storage:
     managed_table_storage: s3

--- a/scripts/lib/deploy.sh
+++ b/scripts/lib/deploy.sh
@@ -81,13 +81,17 @@ wait_rollout() {
   return 1
 }
 
-# Run a query through the instance gateway and assert the result contains an
-# expected substring. Mirrors the curl example in docs/quickstart.mdx: the
+# Run a query through the instance gateway and optionally assert the result
+# contains an expected substring. Mirrors the curl example in docs/quickstart.mdx: the
 # gateway Service is <release>-gateway in the same namespace, and the target
 # engine is selected via the X-Firebolt-Engine header.
 #
 # Usage:
 #   run_query <namespace> <gateway-service> <engine> [query] [expected] [attempts] [sleep]
+#
+# An empty expected string means HTTP success is enough. DDL/DML statements may
+# return a 2xx response with no body, while SELECT statements should assert a
+# result substring.
 #
 # A rolled-out engine can still need a few seconds before the gateway routes
 # queries to it (engine HTTP listener warming up), so this polls.
@@ -115,8 +119,12 @@ run_query() {
         -H "X-Firebolt-Engine: ${engine}" \
         -H "Content-Type: text/plain" \
         --data-binary "${query}" 2>/dev/null); then
-      if printf '%s' "${output}" | grep -q "${expected}"; then
-        echo "Query succeeded after ${i} attempt(s); result contains '${expected}':"
+      if [[ -z "${expected}" ]] || printf '%s' "${output}" | grep -q "${expected}"; then
+        if [[ -z "${expected}" ]]; then
+          echo "Query succeeded after ${i} attempt(s)."
+        else
+          echo "Query succeeded after ${i} attempt(s); result contains '${expected}':"
+        fi
         printf '%s\n' "${output}"
         return 0
       fi
@@ -141,11 +149,11 @@ run_managed_table_smoke() {
   local engine="$3"
   local table="helm_storage_smoke"
 
-  run_query "${namespace}" "${gateway}" "${engine}" "DROP TABLE IF EXISTS ${table}" "OK"
-  run_query "${namespace}" "${gateway}" "${engine}" "CREATE TABLE ${table} (id INT, name TEXT)" "OK"
-  run_query "${namespace}" "${gateway}" "${engine}" "INSERT INTO ${table} (id, name) VALUES (1, 'floci'), (2, 'managed-storage')" "OK"
+  run_query "${namespace}" "${gateway}" "${engine}" "DROP TABLE IF EXISTS ${table}" ""
+  run_query "${namespace}" "${gateway}" "${engine}" "CREATE TABLE ${table} (id INT, name TEXT)" ""
+  run_query "${namespace}" "${gateway}" "${engine}" "INSERT INTO ${table} (id, name) VALUES (1, 'floci'), (2, 'managed-storage')" ""
   run_query "${namespace}" "${gateway}" "${engine}" "SELECT name FROM ${table} WHERE id = 2" "managed-storage"
-  run_query "${namespace}" "${gateway}" "${engine}" "DROP TABLE IF EXISTS ${table}" "OK"
+  run_query "${namespace}" "${gateway}" "${engine}" "DROP TABLE IF EXISTS ${table}" ""
 }
 
 # Current pipeline phase and the failure_reason to report if this phase fails.

--- a/scripts/lib/deploy.sh
+++ b/scripts/lib/deploy.sh
@@ -100,7 +100,7 @@ run_query() {
   local gateway="$2"
   local engine="$3"
   local query="${4:-SELECT 1}"
-  local expected="${5:-1}"
+  local expected="${5-1}"
   local attempts="${6:-24}"
   local sleep_seconds="${7:-5}"
 


### PR DESCRIPTION
**Background**

FB-2197: local floci-backed deploys do not need engine AWS credential environment variables, and the helm-test path should prove the configured object storage can back managed tables.

**Summary**

- Remove the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` entries from the values file generated by `scripts/lib/deploy.sh`.
- Remove the same dummy credentials from `helm/values-dev.yaml`.
- Update the quickstart, local floci comments, and internal local-development note so the documented local path only configures the floci storage endpoint.
- Add managed-table SQL coverage to the shared deploy verification and Helm test SQL hook: drop/create/insert/select/drop through the gateway, which exercises the configured floci object-storage path beyond `SELECT 1`.

**Test Plan**

- `make lint`
- `bash -n scripts/lib/deploy.sh`
- `make docs-check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the default local deploy path and engine object-storage wiring; wrong assumptions about floci auth could break local installs, but changes are narrowly scoped to dev docs/values and additive test coverage.
> 
> **Overview**
> **Local floci deploys no longer inject dummy `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` on the engine.** Those `engineSpec.extraEnv` blocks are removed from `helm/values-dev.yaml`, the values snippet built in `scripts/lib/deploy.sh`, and the quickstart / internal docs; copy now states that floci is zero-auth and only needs `customEngineConfig.storage` pointed at the floci endpoint.
> 
> **Deploy and Helm tests now exercise managed-table storage, not just `SELECT 1`.** `run_query` treats an empty expected substring as success (for DDL/DML with no body). `run_managed_table_smoke` in `deploy.sh` runs drop/create/insert/select/drop through the gateway during `deploy_and_verify`, with a dedicated `managed_table` phase for agents. The Helm `test-sql-query` hook uses a shared `sql_query` helper and the same managed-table sequence per engine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e453c36c68d9308d501f80e06df6ee2229082b88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->