### PR TITLE
chore(deps): bump packdb appVersion to release-5.0.1-0.20260727005216.d09b51086f14

### DIFF
--- a/docs/usage/image-overrides.mdx
+++ b/docs/usage/image-overrides.mdx
@@ -37,10 +37,10 @@ You can choose the smaller `release-` versions or use the `debug-` prefix which 
 ```yaml
 engineSpec:
   image:
-    tag: release-5.0.1-0.20260713060957.513515666721
+    tag: release-5.0.1-0.20260727005216.d09b51086f14
 metadata:
   image:
-    tag: release-5.0.1-0.20260713060957.513515666721
+    tag: release-5.0.1-0.20260727005216.d09b51086f14
 ```
 
 ## Lockstep

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -8,4 +8,4 @@ home: "https://github.com/firebolt-db/firebolt-instance-helm"
 sources: ["https://github.com/firebolt-db/firebolt-instance-helm"]
 version: 0.2.0
 # Bumped by upstream image-release automation.
-appVersion: "release-5.0.1-0.20260713060957.513515666721"
+appVersion: "release-5.0.1-0.20260727005216.d09b51086f14"

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # firebolt-instance
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-5.0.1-0.20260713060957.513515666721](https://img.shields.io/badge/AppVersion-release--5.0.1--0.20260713060957.513515666721-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-5.0.1-0.20260727005216.d09b51086f14](https://img.shields.io/badge/AppVersion-release--5.0.1--0.20260727005216.d09b51086f14-informational?style=flat-square)
 
 Firebolt Instance on Kubernetes — Envoy gateway, metadata, auth, and engines
 


### PR DESCRIPTION
## Summary

Bump `appVersion` in `helm/Chart.yaml` to `release-5.0.1-0.20260727005216.d09b51086f14`
— the build the engine/metadata `:latest` GHCR tags were just re-pointed to —
regenerate the `helm/README.md` badge, and refresh the image-overrides example.

> [!NOTE]
> Opened automatically by packdb's `promote-ghcr-latest` workflow (weekly
> Monday refresh or a manual promotion) right after it re-pointed the
> engine/metadata `:latest` GHCR tags at this build, so `:latest` and this
> repo's pinned tags move together. An unmerged PR is overwritten by the
> next run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version pin with no chart template or application logic changes; risk is limited to whatever behavior differs in the new engine/metadata build.
> 
> **Overview**
> Pins the Helm chart default engine/metadata image to **`release-5.0.1-0.20260727005216.d09b51086f14`** by updating `appVersion` in `helm/Chart.yaml`, which drives default tags when `engineSpec.image.tag` and `metadata.image.tag` are empty.
> 
> The **image-overrides** doc example and the **AppVersion** badge in `helm/README.md` are refreshed to the same build so docs and defaults stay aligned with the GHCR `:latest` promotion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2f4d4cf41052b7b870919e19614785db34ea9d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->