### PR TITLE
fix(metadata): render metadata service config as YAML, not XML (FB-3110)

### DIFF
--- a/docs/usage/image-overrides.mdx
+++ b/docs/usage/image-overrides.mdx
@@ -37,10 +37,10 @@ You can choose the smaller `release-` versions or use the `debug-` prefix which 
 ```yaml
 engineSpec:
   image:
-    tag: release-5.0.1-0.20260727005216.d09b51086f14
+    tag: release-5.0.0-pre.0.20260815074041.524de236b514
 metadata:
   image:
-    tag: release-5.0.1-0.20260727005216.d09b51086f14
+    tag: release-5.0.0-pre.0.20260815074041.524de236b514
 ```
 
 ## Lockstep

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -12,4 +12,4 @@ sources:
   - "https://github.com/firebolt-db/firebolt-instance-helm"
 version: 0.3.0
 # Bumped by upstream image-release automation.
-appVersion: "release-5.0.1-0.20260727005216.d09b51086f14"
+appVersion: "release-5.0.0-pre.0.20260815074041.524de236b514"

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # firebolt-instance
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-5.0.1-0.20260727005216.d09b51086f14](https://img.shields.io/badge/AppVersion-release--5.0.1--0.20260727005216.d09b51086f14-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-5.0.0-pre.0.20260815074041.524de236b514](https://img.shields.io/badge/AppVersion-release--5.0.0--pre.0.20260815074041.524de236b514-informational?style=flat-square)
 
 Firebolt Instance on Kubernetes — Envoy gateway, metadata, auth, and engines
 

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -375,17 +375,6 @@ Usage: {{ include "fbinstance.engineTlsDnsNames" . }}
 {{- end -}}
 
 {{/*
-XML element-text escape for user-controlled strings interpolated into the
-rendered metadata config.xml. Replaces the three element-content
-metacharacters; the `&` substitution MUST run first so its entity
-reference isn't re-escaped. Defense-in-depth alongside the
-values.schema.json patterns.
-*/}}
-{{- define "fbinstance.xmlEscape" -}}
-{{- . | replace "&" "&amp;" | replace "<" "&lt;" | replace ">" "&gt;" -}}
-{{- end -}}
-
-{{/*
 Memlock setup sidecar script — loaded from files/memlock-setup.sh
 */}}
 {{- define "fbinstance.memlockSetupScript" -}}

--- a/helm/templates/metadata-service-configmap.yaml
+++ b/helm/templates/metadata-service-configmap.yaml
@@ -7,39 +7,35 @@ metadata:
     {{- include "fbinstance.labels" . | nindent 4 }}
     firebolt/component: metadata-service
 data:
-  config.xml: |
-    <?xml version="1.0"?>
-    <config>
-      <pensieve_lite>
-        <default_account_id>{{ include "fbinstance.xmlEscape" .Values.customEngineConfig.instance.id }}</default_account_id>
-        <host>{{ include "fbinstance.xmlEscape" .Values.metadata.server.host }}</host>
-        <port>{{ .Values.metadata.server.port }}</port>
-        <server_threads>{{ .Values.metadata.server.threads }}</server_threads>
-        <log_level>{{ include "fbinstance.xmlEscape" .Values.metadata.server.log_level }}</log_level>
-        <metadata_storage>
-          <postgresql>
-            {{- if .Values.postgresql.local_enabled }}
-            <host>{{ include "fbinstance.fullname" . }}-metadata-pg</host>
-            {{- else }}
-            <host>{{ include "fbinstance.xmlEscape" .Values.postgresql.host }}</host>
-            {{- end }}
-            <port>{{ .Values.postgresql.port }}</port>
-            <database>{{ include "fbinstance.xmlEscape" .Values.postgresql.database }}</database>
-            <schema>{{ include "fbinstance.xmlEscape" .Values.postgresql.schema }}</schema>
-
-            <keepalive>
-              <enabled>{{ .Values.postgresql.keepalive.enabled }}</enabled>
-              <idle_sec>{{ .Values.postgresql.keepalive.idle_sec }}</idle_sec>
-              <interval_sec>{{ .Values.postgresql.keepalive.interval_sec }}</interval_sec>
-              <count>{{ .Values.postgresql.keepalive.count }}</count>
-            </keepalive>
-            <connect_timeout_sec>{{ .Values.postgresql.connect_timeout_sec }}</connect_timeout_sec>
-          </postgresql>
-          <garbage_collection>
-            <enabled>true</enabled>
-            <interval_seconds>3600</interval_seconds>
-            <max_age_seconds>86400</max_age_seconds>
-          </garbage_collection>
-        </metadata_storage>
-      </pensieve_lite>
-    </config>
+  # The metadata service loads YAML config only; the document root must be
+  # a map (a scalar/sequence root is rejected at startup). User-controlled
+  # strings are rendered as quoted scalars so they cannot inject YAML keys.
+  config.yaml: |
+    pensieve_lite:
+      default_account_id: {{ .Values.customEngineConfig.instance.id | quote }}
+      host: {{ .Values.metadata.server.host | quote }}
+      port: {{ .Values.metadata.server.port }}
+      server_threads: {{ .Values.metadata.server.threads }}
+      log_level: {{ .Values.metadata.server.log_level | quote }}
+      metadata_storage:
+        postgresql:
+          {{- if .Values.postgresql.local_enabled }}
+          host: {{ printf "%s-metadata-pg" (include "fbinstance.fullname" .) | quote }}
+          {{- else }}
+          host: {{ .Values.postgresql.host | quote }}
+          {{- end }}
+          port: {{ .Values.postgresql.port }}
+          database: {{ .Values.postgresql.database | quote }}
+          schema: {{ .Values.postgresql.schema | quote }}
+          keepalive:
+            enabled: {{ .Values.postgresql.keepalive.enabled }}
+            idle_sec: {{ .Values.postgresql.keepalive.idle_sec }}
+            interval_sec: {{ .Values.postgresql.keepalive.interval_sec }}
+            count: {{ .Values.postgresql.keepalive.count }}
+          connect_timeout_sec: {{ .Values.postgresql.connect_timeout_sec }}
+        garbage_collection:
+          enabled: true
+          # The server reads interval_ms / time_horizon_sec; other spellings
+          # are silently ignored and the built-in defaults take over.
+          interval_ms: 3600000
+          time_horizon_sec: 86400

--- a/helm/templates/metadata-service-deployment.yaml
+++ b/helm/templates/metadata-service-deployment.yaml
@@ -85,7 +85,7 @@ spec:
         - name: metadata-service
           image: "{{ .Values.metadata.image.repository }}:{{ default .Chart.AppVersion .Values.metadata.image.tag }}"
           imagePullPolicy: {{ .Values.metadata.image.pullPolicy }}
-          command: ["/dedicated-pensieve", "--config", "/configs/config.xml"]
+          command: ["/dedicated-pensieve", "--config", "/configs/config.yaml"]
           ports:
             - name: grpc
               containerPort: {{ .Values.metadata.server.port }}


### PR DESCRIPTION
**Background**

FB-3110: newer metadata service images load YAML configuration only and reject the chart's `config.xml` at startup ("Configuration root cannot be scalar or sequence"), crash-looping the metadata Deployment — this is what failed helm-test on #57.

**Summary**

- Render the metadata ConfigMap as `config.yaml` — a YAML map rooted at `pensieve_lite:` — and start the container with `--config /configs/config.yaml`.
- User-controlled strings are rendered as quoted YAML scalars; the `fbinstance.xmlEscape` helper is gone.
- Fixes the GC keys along the way: the server reads `interval_ms` / `time_horizon_sec`, the old `interval_seconds` / `max_age_seconds` were silently ignored.
- Bumps `appVersion` to `release-5.0.0-pre.0.20260815074041.524de236b514` in the same commit — older metadata images are XML-only, so config format and default image have to move together. Supersedes the appVersion bump in #57.

Going forward the chart requires a metadata image that loads YAML config; `metadata.image.tag` overrides pointing at older builds won't start.

**Test Plan**

Chart-level: helm lint plus the full validate-chart pipeline (rendered output passes yamllint); rendered config verified against the schema the server parses.

Runtime: end-to-end kind deployment with the new default image — metadata service reaches Ready on the YAML config (previously instant CrashLoopBackOff), queries route through the gateway, managed-table write/read against floci, and the chart's full helm test suite passes. The helm-test PR gate exercises the same path.