### PR TITLE
chore(deps): bump packdb appVersion to release-5.0.0-pre.0.20260822175432.75d37cc26c66

### DIFF
--- a/docs/usage/image-overrides.mdx
+++ b/docs/usage/image-overrides.mdx
@@ -37,10 +37,10 @@ You can choose the smaller `release-` versions or use the `debug-` prefix which 
 ```yaml
 engineSpec:
   image:
-    tag: release-5.0.0-pre.0.20260815074041.524de236b514
+    tag: release-5.0.0-pre.0.20260822175432.75d37cc26c66
 metadata:
   image:
-    tag: release-5.0.0-pre.0.20260815074041.524de236b514
+    tag: release-5.0.0-pre.0.20260822175432.75d37cc26c66
 ```
 
 ## Lockstep

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -12,4 +12,4 @@ sources:
   - "https://github.com/firebolt-db/firebolt-instance-helm"
 version: 0.3.1
 # Bumped by upstream image-release automation.
-appVersion: "release-5.0.0-pre.0.20260815074041.524de236b514"
+appVersion: "release-5.0.0-pre.0.20260822175432.75d37cc26c66"

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # firebolt-instance
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-5.0.0-pre.0.20260815074041.524de236b514](https://img.shields.io/badge/AppVersion-release--5.0.0--pre.0.20260815074041.524de236b514-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-5.0.0-pre.0.20260822175432.75d37cc26c66](https://img.shields.io/badge/AppVersion-release--5.0.0--pre.0.20260822175432.75d37cc26c66-informational?style=flat-square)
 
 Firebolt Instance on Kubernetes — Envoy gateway, metadata, auth, and engines
 


### PR DESCRIPTION
## Summary

Bump `appVersion` in `helm/Chart.yaml` to `release-5.0.0-pre.0.20260822175432.75d37cc26c66`
— the build the engine/metadata `:latest` GHCR tags were just re-pointed to —
regenerate the `helm/README.md` badge, and refresh the image-overrides example.

> [!NOTE]
> Opened automatically by packdb's `promote-ghcr-latest` workflow (weekly
> Monday refresh or a manual promotion) right after it re-pointed the
> engine/metadata `:latest` GHCR tags at this build, so `:latest` and this
> repo's pinned tags move together. An unmerged PR is overwritten by the
> next run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default engine and metadata images used on install/upgrade, so clusters that do not override tags will roll those workloads. No chart logic or security-surface changes.
> 
> **Overview**
> Pins the chart’s default engine and metadata image tag (`Chart.yaml` `appVersion`) to `release-5.0.0-pre.0.20260822175432.75d37cc26c66`, matching the build that `:latest` was just re-pointed to.
> 
> Chart `version` stays `0.3.1`. The helm-docs AppVersion badge and the lockstep example in `docs/usage/image-overrides.mdx` are updated to the same tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2bd256c3a6d7d86a49bc8335ef343633cdb20fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->