### PR TITLE
docs: add Tigris and Cloudflare R2 to S3-compatible storage; remove outdated warning box (FB-3391)

### DIFF
--- a/docs/usage/object-storage/s3-compatible.mdx
+++ b/docs/usage/object-storage/s3-compatible.mdx
@@ -4,10 +4,6 @@ description: Back Firebolt engines with a non-AWS S3-compatible object store (Ne
 sidebarTitle: S3-compatible
 ---
 
-<Warning>
-  **Breaking change.** Managed-table storage now uses `managed_table_storage` and `managed_table_bucket_name` with a per-cloud `storage.aws` / `gcp` / `azure` block. The former keys — `type`, `api_scheme`, `bucket_name`, and the `minio` / `azurite` types — are removed and are rejected by the engine at startup. This schema requires a recent engine image; keep the chart and engine on matching versions.
-</Warning>
-
 Besides Amazon S3, the engine can use any **S3-compatible** object store — for example [Nebius](https://nebius.com/) Object Storage, [CoreWeave](https://www.coreweave.com/) Object Storage, or a self-hosted [MinIO](https://min.io/). You point the engine at the store's endpoint and supply credentials through the engine container environment.
 
 ## How it differs from Amazon S3
@@ -68,6 +64,64 @@ customEngineConfig:
     aws:
       endpoint: https://<coreweave-object-storage-endpoint>
       path_style_addressing: false # CoreWeave supports virtual-hosted addressing only
+```
+
+## Tigris
+
+[Tigris](https://www.tigrisdata.com/) exposes a global S3 API endpoint at `https://t3.storage.dev` and supports path-style addressing (the default).
+
+Create a `Secret` from a Tigris access key:
+
+```bash
+kubectl -n firebolt create secret generic tigris-s3-credentials \
+  --from-literal=AWS_ACCESS_KEY_ID=<tigris-access-key-id> \
+  --from-literal=AWS_SECRET_ACCESS_KEY=<tigris-secret>
+```
+
+```yaml
+# my-values.yaml
+engineSpec:
+  extraEnvFrom:
+    - secretRef:
+        name: tigris-s3-credentials
+
+customEngineConfig:
+  storage:
+    managed_table_storage: s3
+    managed_table_bucket_name: my-firebolt-bucket
+    aws:
+      endpoint: https://t3.storage.dev
+      region: auto
+      path_style_addressing: true # non-AWS S3-compatible store; ignored for AWS S3
+```
+
+## Cloudflare R2
+
+[Cloudflare R2](https://developers.cloudflare.com/r2/) exposes an account-scoped S3 API endpoint at `https://<account-id>.r2.cloudflarestorage.com` and supports path-style addressing. R2 ignores the signing region, so set `region: auto`.
+
+Create a `Secret` from an R2 API token (S3 credentials):
+
+```bash
+kubectl -n firebolt create secret generic r2-s3-credentials \
+  --from-literal=AWS_ACCESS_KEY_ID=<r2-access-key-id> \
+  --from-literal=AWS_SECRET_ACCESS_KEY=<r2-secret>
+```
+
+```yaml
+# my-values.yaml
+engineSpec:
+  extraEnvFrom:
+    - secretRef:
+        name: r2-s3-credentials
+
+customEngineConfig:
+  storage:
+    managed_table_storage: s3
+    managed_table_bucket_name: my-firebolt-bucket
+    aws:
+      endpoint: https://<account-id>.r2.cloudflarestorage.com
+      region: auto
+      path_style_addressing: true
 ```
 
 ## Confirm that object storage works


### PR DESCRIPTION
Adds Tigris and Cloudflare R2 to the S3-compatible storage page, following the existing Nebius/CoreWeave pattern. Endpoint and credential mechanism (endpoint in the engine config, credentials via env-var Secret) verified on Firebolt Core; not deployed end-to-end through the operator. Also removes the outdated breaking-change warning box at the top of the page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, config schema, or deployment behavior changes.
> 
> **Overview**
> Updates the **S3-compatible storage** doc by dropping the top **Warning** about the old `managed_table_storage` schema migration, which is no longer needed on this page.
> 
> Adds two provider sections that mirror Nebius/CoreWeave: **Tigris** (`https://t3.storage.dev`, path-style, `region: auto`) and **Cloudflare R2** (account-scoped endpoint, path-style, `region: auto`). Each includes `kubectl` Secret examples and `engineSpec.extraEnvFrom` + `customEngineConfig.storage.aws` Helm values for static S3 credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9412911b4354199ad28312003491c3f92241e470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->