### PR TITLE
chore(deps): bump packdb appVersion to release-5.0.0-pre.0.20260828194119.d0f954993097

### DIFF
--- a/docs/usage/image-overrides.mdx
+++ b/docs/usage/image-overrides.mdx
@@ -37,10 +37,10 @@ You can choose the smaller `release-` versions or use the `debug-` prefix which 
 ```yaml
 engineSpec:
   image:
-    tag: release-5.0.0-pre.0.20260822175432.75d37cc26c66
+    tag: release-5.0.0-pre.0.20260828194119.d0f954993097
 metadata:
   image:
-    tag: release-5.0.0-pre.0.20260822175432.75d37cc26c66
+    tag: release-5.0.0-pre.0.20260828194119.d0f954993097
 ```
 
 ## Lockstep

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -12,4 +12,4 @@ sources:
   - "https://github.com/firebolt-db/firebolt-instance-helm"
 version: 0.3.2
 # Bumped by upstream image-release automation.
-appVersion: "release-5.0.0-pre.0.20260822175432.75d37cc26c66"
+appVersion: "release-5.0.0-pre.0.20260828194119.d0f954993097"

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # firebolt-instance
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-5.0.0-pre.0.20260822175432.75d37cc26c66](https://img.shields.io/badge/AppVersion-release--5.0.0--pre.0.20260822175432.75d37cc26c66-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-5.0.0-pre.0.20260828194119.d0f954993097](https://img.shields.io/badge/AppVersion-release--5.0.0--pre.0.20260828194119.d0f954993097-informational?style=flat-square)
 
 Firebolt Instance on Kubernetes — Envoy gateway, metadata, auth, and engines
 


### PR DESCRIPTION
## Summary

Bump `appVersion` in `helm/Chart.yaml` to `release-5.0.0-pre.0.20260828194119.d0f954993097`
— the build the engine/metadata `:latest` GHCR tags were just re-pointed to —
regenerate the `helm/README.md` badge, and refresh the image-overrides example.

> [!NOTE]
> Opened automatically by packdb's `promote-ghcr-latest` workflow (weekly
> Monday refresh or a manual promotion) right after it re-pointed the
> engine/metadata `:latest` GHCR tags at this build, so `:latest` and this
> repo's pinned tags move together. An unmerged PR is overwritten by the
> next run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine automation-only version pin and doc/badge sync; no chart logic, values defaults, or templates change.
> 
> **Overview**
> Updates the Helm chart’s pinned **engine/metadata** build from `release-5.0.0-pre.0.20260822175432.75d37cc26c66` to **`release-5.0.0-pre.0.20260828194119.d0f954993097`** by changing `appVersion` in `helm/Chart.yaml` (chart `version` stays **0.3.2**).
> 
> The `helm/README.md` AppVersion badge and the pinned-tag example in `docs/usage/image-overrides.mdx` are refreshed so docs match the new default image tag when `engineSpec.image.tag` / `metadata.image.tag` are left empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7090a18afabe1be42a7d882d4d8fe2805d3c8fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->