### PR TITLE
chore(deps): bump packdb appVersion to release-5.0.0-pre.0.20260831081410.a005be0f9030

### DIFF
--- a/docs/usage/image-overrides.mdx
+++ b/docs/usage/image-overrides.mdx
@@ -37,10 +37,10 @@ You can choose the smaller `release-` versions or use the `debug-` prefix which 
 ```yaml
 engineSpec:
   image:
-    tag: release-5.0.0-pre.0.20260828194119.d0f954993097
+    tag: release-5.0.0-pre.0.20260831081410.a005be0f9030
 metadata:
   image:
-    tag: release-5.0.0-pre.0.20260828194119.d0f954993097
+    tag: release-5.0.0-pre.0.20260831081410.a005be0f9030
 ```
 
 ## Lockstep

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -12,4 +12,4 @@ sources:
   - "https://github.com/firebolt-db/firebolt-instance-helm"
 version: 0.4.0
 # Bumped by upstream image-release automation.
-appVersion: "release-5.0.0-pre.0.20260828194119.d0f954993097"
+appVersion: "release-5.0.0-pre.0.20260831081410.a005be0f9030"

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # firebolt-instance
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-5.0.0-pre.0.20260828194119.d0f954993097](https://img.shields.io/badge/AppVersion-release--5.0.0--pre.0.20260828194119.d0f954993097-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-5.0.0-pre.0.20260831081410.a005be0f9030](https://img.shields.io/badge/AppVersion-release--5.0.0--pre.0.20260831081410.a005be0f9030-informational?style=flat-square)
 
 Firebolt Instance on Kubernetes — Envoy gateway, metadata, auth, and engines
 


### PR DESCRIPTION
## Summary

Bump `appVersion` in `helm/Chart.yaml` to `release-5.0.0-pre.0.20260831081410.a005be0f9030`
— the build the engine/metadata `:latest` GHCR tags were just re-pointed to —
regenerate the `helm/README.md` badge, and refresh the image-overrides example.

> [!NOTE]
> Opened automatically by packdb's `promote-ghcr-latest` workflow (weekly
> Monday refresh or a manual promotion) right after it re-pointed the
> engine/metadata `:latest` GHCR tags at this build, so `:latest` and this
> repo's pinned tags move together. An unmerged PR is overwritten by the
> next run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin and documentation-only changes with no chart logic or security-sensitive edits; risk is limited to deploying a newer pre-release engine/metadata pair when defaults are used.
> 
> **Overview**
> Pins the Helm chart’s default engine and metadata images to **`release-5.0.0-pre.0.20260831081410.a005be0f9030`** by updating `appVersion` in `helm/Chart.yaml`, keeping the chart aligned with the GHCR `:latest` promotion for that build.
> 
> The `helm/README.md` AppVersion badge and the lockstep override example in `docs/usage/image-overrides.mdx` are refreshed to the same tag. Chart version stays **0.4.0**; installs that leave `engineSpec.image.tag` and `metadata.image.tag` empty will pull the new build on the next upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18e4e1d4ee68006474916acc07b964c98d27cd07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->